### PR TITLE
[Feature-0007] feat: adjusting endpoint.

### DIFF
--- a/src/modules/party/party.controller.ts
+++ b/src/modules/party/party.controller.ts
@@ -77,13 +77,13 @@ export class PartyController {
       return parties.map((party) => new PartyPresenter(party));
    }
 
-   @GetApiResponse(PartyPresenter, '/guest/me')
+   @GetApiResponse(PartyPresenter, '/guest/:id')
    public async findAllGuestParties(
-      @Req() req: IAuth,
+      @Param('id') id: string,
    ): Promise<PartyPresenter[]> {
       const parties = await this.findAllGuestPartiesUseCase
          .getInstance()
-         .execute(req.user.id);
+         .execute(id);
 
       return parties.map((party) => new PartyPresenter(party));
    }

--- a/test/unit/modules/party/party.controller.spec.ts
+++ b/test/unit/modules/party/party.controller.spec.ts
@@ -150,8 +150,6 @@ describe('PartyController', () => {
 
    describe('findAllGuestParties', () => {
       it('should find all guest parties using the findAllGuestParties method', async () => {
-         const mockReq = { user: { id: '1', username: '' } };
-
          jest
             .spyOn(
                partyController['findAllGuestPartiesUseCase'].getInstance(),
@@ -159,7 +157,7 @@ describe('PartyController', () => {
             )
             .mockResolvedValue(partyList);
 
-         const result = await partyController.findAllGuestParties(mockReq);
+         const result = await partyController.findAllGuestParties('1');
 
          expect(result).toBeInstanceOf(Array);
          result.forEach((party) =>
@@ -167,7 +165,7 @@ describe('PartyController', () => {
          );
          expect(
             partyController['findAllGuestPartiesUseCase'].getInstance().execute,
-         ).toHaveBeenCalledWith(mockReq.user.id);
+         ).toHaveBeenCalledWith('1');
       });
    });
 


### PR DESCRIPTION
feat: update findAllGuestParties endpoint to use guest ID parameter

Refactor the `findAllGuestParties` endpoint in the `PartyController` to use the guest ID parameter instead of the `req` object. This change improves the clarity and maintainability of the code. The `findAllGuestParties` method now accepts the guest ID as a parameter named `id` and passes it to the `execute` method of the `findAllGuestPartiesUseCase`. This ensures that the correct guest parties are retrieved and returned in the response.